### PR TITLE
[BACKPLANE-1120] Push a SNAPSHOT version to Clojars instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,16 +56,12 @@ workflows:
   build-test:
     jobs:
       - clj-kondo
-      - test-deps-plus:
-          filters:
-            tags:
-              only: /.*/
+      - test-deps-plus
       - publish:
           context: clojars-publish
           requires:
             - test-deps-plus
           filters:
-            tags:
-              only: /.*/
             branches:
-              ignore: /.*/
+              only:
+                - main

--- a/README.adoc
+++ b/README.adoc
@@ -4,11 +4,11 @@ deps-plus is a Leiningen plugin designed to help with analyzing project dependen
 
 == Installation
 
-Add `+[com.circleci/deps-plus "0.1.0"]+` to your `+:user+` profile plugins in `+~/.lein/profiles.clj+`. For example,
+Add `+[com.circleci/deps-plus "0.1.0-SNAPSHOT"]+` to your `+:user+` profile plugins in `+~/.lein/profiles.clj+`. For example,
 
 [source,clj]
 ....
-{:user {:plugins [[com.circleci/deps-plus "0.1.0"]]}}
+{:user {:plugins [[com.circleci/deps-plus "0.1.0-SNAPSHOT"]]}}
 ....
 
 == Usage
@@ -246,17 +246,15 @@ bottom of the dependency knot.  It's also the version that the project explicitl
 Releasing
 ---------
 
-New git tags are automatically published to Clojars. To find the most recent version of lein-deps-plus, look at the most recent tag in Clojars.
+deps-plus is pushed to https://clojars.org/com.circleci/deps-plus[clojars.org] as a SNAPSHOT release.
 
-The following should be updated on the `main` branch before tagging:
+Bump the version *only* when backwards-incompatible changes are made.
+
+The following should be updated on the `main` branch if there are new releases:
 
 - `project.clj` - version
+- `README.adoc` - dependency coordinates
 - `CHANGELOG.adoc` - summary of changes
-
-Using semantic versioning is recommended, increment the:
-1. MAJOR version when you make backward incompatible changes.
-2. MINOR version when you add user-facing features in a backward compatible manner.
-3. PATCH version when you make backward compatible bug fixes.
 
 License
 -------

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.circleci/deps-plus "0.1.0"
+(defproject com.circleci/deps-plus "0.1.0-SNAPSHOT"
   :plugins [[jonase/eastwood "0.3.6" :exclusions [org.clojure/clojure]]]
 
   :pedantic? :abort


### PR DESCRIPTION
Update ci config and releasing doc accordingly.

# Checklist

- [ ] Updated the version, if [applicable](../blob/main/README.adoc#releasing)
- [ ] Updated the [CHANGELOG.adoc](../blob/main/CHANGELOG.adoc), if applicable
- [ ] Updated any documentation (READMEs and docstrings), if applicable
