### PR TITLE
Bump to latest patched versions of guava and jsoup

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,8 +9,12 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog].
 
 = 2021
 
-== 0.1.X - 2021-10-08
+== 2021-11-08
+=== Security
 
+* Bumped guava and jsoup to address CVE vulnerabilities: CVE-2020-8908, CVE-2021-37714
+
+== 2021-10-08
 === Added
 
 * Initial release. All commits are squashed for safety reasons. The original repository lives in GitHub's CircleCI-Archived org.

--- a/project.clj
+++ b/project.clj
@@ -10,8 +10,8 @@
                                   [lambdaisland/kaocha-cloverage "0.0-41"]
                                   [lambdaisland/kaocha-junit-xml "0.0-70"]]}
              :provided {:dependencies [[org.clojure/clojure]
-                                       [com.google.guava/guava "24.1.1-jre"]
-                                       [org.jsoup/jsoup "1.9.2"]
+                                       [com.google.guava/guava "30.0-jre"]
+                                       [org.jsoup/jsoup "1.14.2"]
                                        [leiningen/leiningen "2.9.1"]]}}
 
   :aliases {"test"    ["run" "-m" "kaocha.runner"]


### PR DESCRIPTION
guava and jsoup have newer patched versions available.

# Checklist

- [ ] Updated the version, if [applicable](../blob/main/README.adoc#releasing)
- [X] Updated the [CHANGELOG.adoc](../blob/main/CHANGELOG.adoc), if applicable
- [ ] Updated any documentation (READMEs and docstrings), if applicable
