### PR TITLE
Add check-forbidden-dependencies command

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog].
 
+= 2025
+== 2025-08-22
+=== Added
+
+* Added the `check-forbidden-dependencies` command
+
 = 2021
 
 == 2021-11-08

--- a/README.adoc
+++ b/README.adoc
@@ -27,6 +27,7 @@ To run a deps-plus task simply run `+lein deps-plus <task name>+` from a Leining
 * link:#check-classpath-conflicts[*check-classpath-conflicts*] - Checks for classpath conflicts.
 * link:#check-downgraded[*check-downgraded*] - Checks for dependencies which have been downgraded.
 * link:#check-families[*check-families*] - Checks for inconsistent dependency versions within families.
+* link:#check-forbidden-dependencies[*check-forbidden-dependencies*] - Checks dependencies to ensure none of them are listed in :forbidden-dependencies.
 * link:#check-management-conflicts[*check-management-conflicts*] - Checks for dependency management conflicts.
 * link:#check-pedantic[*check-pedantic*] - Checks for version conflicts and version ranges.
 
@@ -143,6 +144,24 @@ suspicious combinations that has the _undesired_ version, add an entry in the `:
 ....
 
 For completeness, you can add _every_ member of the family the project uses to managed dependencies.
+
+==== check-forbidden-dependencies
+
+A dependency is considered "forbidden" if it's listed at the `:forbidden-dependencies` key in
+`project.clj`. While it's possible to use a global `:exclusions` to remove a dependency from the
+dependency tree, Leiningen copies those exclusions into every dependency reference. If that list
+becomes sufficiently large then Leiningen begins to struggle. Even with relatively small amounts of
+items in `:exclusions` it can clutter `lein deps :tree` output to the point of unreadability.
+
+[source,clj]
+....
+  :forbidden-dependencies [io.grpc/grpc-all] ; Force specific gRPC dependencies
+....
+
+....
+$ lein deps-plus check-forbidden-dependencies
+[ERROR] Forbidden dependency: io.grpc/grpc-all
+....
 
 ==== check-management-conflicts
 

--- a/src/leiningen/deps_plus.clj
+++ b/src/leiningen/deps_plus.clj
@@ -249,10 +249,19 @@
         project (project/merge-profiles project [{:dependencies dependencies}])]
     (lein/resolve-and-apply project args)))
 
+(defn check-forbidden-dependencies
+  "Checks dependencies to ensure none of them are listed in :forbidden-dependencies."
+  [project]
+  (when-let [forbidden-deps (deps/check-forbidden-dependencies project)]
+    (doseq [dep forbidden-deps]
+      (lein/warn "[ERROR] Forbidden dependency:" dep))
+    (lein/exit 1)))
+
 (defn deps-plus
   "Extra tasks for analyzing dependencies"
   {:subtasks [#'list #'list-save #'list-diff #'check-downgraded #'check-families #'check-pedantic
-              #'check-management-conflicts #'check-classpath-conflicts #'why #'who-shades]}
+              #'check-management-conflicts #'check-classpath-conflicts #'why #'who-shades
+              #'check-forbidden-dependencies]}
   [project & [sub-task & args]]
   (let [project (project/unmerge-profiles project [:base :user])]
     (case sub-task
@@ -261,6 +270,7 @@
       "list-diff" (list-diff project)
       "check-downgraded" (check-downgraded project)
       "check-families" (check-families project)
+      "check-forbidden-dependencies" (check-forbidden-dependencies project)
       "check-pedantic" (apply check-pedantic project args)
       "check-management-conflicts" (check-management-conflicts project)
       "check-classpath-conflicts" (check-classpath-conflicts project)

--- a/test-projects/forbidden-dependencies.clj
+++ b/test-projects/forbidden-dependencies.clj
@@ -1,0 +1,8 @@
+(defproject deps-plus-tests/forbidden-dependencies "0-SNAPSHOT"
+  :managed-dependencies [[io.grpc/grpc-all "1.70.0"]
+                         [io.netty/netty-all "4.1.118.Final"]]
+  :dependencies [[com.taoensso/nippy "3.6.0"]
+                 [io.netty/netty-all]]
+  :forbidden-dependencies [com.taoensso/nippy      ; Banned direct dependency
+                           io.grpc/grpc-all        ; Banned but not used managed dependency
+                           io.netty/netty-common]) ; Banned transitive dependency

--- a/test/circleci/deps_plus/core_test.clj
+++ b/test/circleci/deps_plus/core_test.clj
@@ -272,3 +272,12 @@
           target  (deps/parse-coordinates "super-fake:so-fake:jar:what-big-versions")
           result  (deps/who-shades* project target)]
       (is (empty? result)))))
+
+(deftest check-forbidden-dependencies
+  (testing "When there are no forbidden dependencies"
+    (let [project (lein-project/read "test-projects/shaded-dependencies.clj")]
+      (is (nil? (deps/check-forbidden-dependencies project)))))
+  (testing "When there are forbidden dependencies"
+    (let [project (lein-project/read "test-projects/forbidden-dependencies.clj")]
+      (is (= #{'com.taoensso/nippy 'io.netty/netty-common}
+             (deps/check-forbidden-dependencies project))))))


### PR DESCRIPTION
This allows us to add a `:forbidden-dependencies` key which contains a list of dependencies which are not permitted to be in the dependency tree either directly or transitively.

# Checklist

- [X] Updated the version, if [applicable](../blob/main/README.adoc#releasing)
- [X] Updated the [CHANGELOG.adoc](../blob/main/CHANGELOG.adoc), if applicable
- [X] Updated any documentation (READMEs and docstrings), if applicable
