### PR TITLE
Make Renovate ignore test-projects/*

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "separateMajorMinor": false,
   "labels": ["renovate"],
   "groupName": "uncategorized",
+  "ignorePaths": ["test-projects/**"],
   "packageRules": [
     {
       "matchDatasources": ["clojure"],


### PR DESCRIPTION
These aren't real dependencies so they pose no security risk.